### PR TITLE
chore(circle): remove github access

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,6 @@ jobs:
           keys:
             - vendor-{{ checksum "Gopkg.lock" }}
       - run:
-          name: Configure Github Access
-          command: echo "machine github.com login $GITHUB_USER password $GITHUB_PASS" >> ~/.netrc
-      - run:
           name: Setup project
           command: make setup
       - run:


### PR DESCRIPTION
## What & Why
Remove GitHub machine access. It was never needed for this project to begin with since we weren't fetching any private packages. I've deleted the corresponding environment variables in CircleCI and deactivated the auth token from the machine user. 