### PR TITLE
fix(lambda): print a newline at the end of each metric

### DIFF
--- a/pkg/lambda/lambda.go
+++ b/pkg/lambda/lambda.go
@@ -72,6 +72,8 @@ func (l *Client) send(name string, value string, tags []string, metricType strin
 		buffer.WriteString(tag)
 	}
 
+	buffer.WriteRune('\n')
+
 	_, err := l.writer.Write(buffer.Bytes())
 	return err
 }

--- a/pkg/lambda/lambda_test.go
+++ b/pkg/lambda/lambda_test.go
@@ -86,7 +86,7 @@ func TestCount(t *testing.T) {
 
 		got := w.buffer.String()
 		want := fmt.Sprintf(
-			"MONITORING|%d|%s|%s|%s%s|#%s",
+			"MONITORING|%d|%s|%s|%s%s|#%s\n",
 			time.Now().Unix(),
 			strconv.FormatInt(testCount, 10),
 			"count",
@@ -110,7 +110,7 @@ func TestGauge(t *testing.T) {
 
 		got := w.buffer.String()
 		want := fmt.Sprintf(
-			"MONITORING|%d|%s|%s|%s%s|#%s",
+			"MONITORING|%d|%s|%s|%s%s|#%s\n",
 			time.Now().Unix(),
 			strconv.FormatFloat(testValue, 'f', -1, 64),
 			"gauge",
@@ -134,7 +134,7 @@ func TestHistogram(t *testing.T) {
 
 		got := w.buffer.String()
 		want := fmt.Sprintf(
-			"MONITORING|%d|%s|%s|%s%s|#%s",
+			"MONITORING|%d|%s|%s|%s%s|#%s\n",
 			time.Now().Unix(),
 			strconv.FormatFloat(testValue, 'f', -1, 64),
 			"histogram",
@@ -165,7 +165,7 @@ func TestSend(t *testing.T) {
 
 		got := w.buffer.String()
 		want := fmt.Sprintf(
-			"MONITORING|%d|%s|%s|%s%s|#%s",
+			"MONITORING|%d|%s|%s|%s%s|#%s\n",
 			now,
 			value,
 			metricType,


### PR DESCRIPTION
**what and why:**
We want to write a line for each lambda metric, so this makes sure we add a newline in the command!